### PR TITLE
Incorrect type ResponseOptions used in README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 fetch is a high level HTTP Request Library that gives you a javascript fetch like API. It also supports making asynchronous/non-blocking requests, check out [this example](https://github.com/instanceofMA/arduino-fetch/blob/main/examples/esp8266/async/get/get.ino) and [others](https://github.com/instanceofMA/arduino-fetch/blob/main/examples).
 
 ```js
-ResponseOptions options;
+RequestOptions options;
 options.method = "POST";
 // options.fingerprint = "DC 78 3C 09 3A 78 E3 A0 BA A9 C5 4F 7A A0 87 6F 89 01 71 4C";
 options.caCert = "";
@@ -57,7 +57,7 @@ RequestOptions options;
     }
 */
 
-ResponseOptions options;
+RequestOptions options;
 options.method = "POST";
 options.headers["Content-Type"] = "application/json";
 options.headers["Connection"] = "keep-alive";
@@ -65,7 +65,7 @@ options.body = "email=EMAIL&password=PASSWORD";
 ```
 
 <!-- ```cpp
-ResponseOptions options;
+RequestOptions options;
 options["method"] = "POST";
 options["body"] = "email=EMAIL&password=PASSWORD";
 ``` -->


### PR DESCRIPTION
Hello,

Thanks for making this great library! It seems to work well, although in the process of trying it out I did find a minor issue with the docs.

The type for the `options` object was incorrectly documented as being `ResponseOptions`, when it's actually `RequestOptions`.
I thought it may have been left over from a previous release, but looking through the commits this type doesn't seem to have ever existed).

I was confused for a little while today after adding Fetch to my project by following the README, and getting a compilation error:
```none
src/main.cpp:56:3: error: 'ResponseOptions' was not declared in this scope
   ResponseOptions options;
   ^
```

In retrospect it makes much more sense for it to be an instance of `RequestOptions` when I'm sending a request, not configuring the response – I'm not sure what this would even mean :-)